### PR TITLE
Changes necessary for the new iOS App 11.7.1

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -6,7 +6,7 @@ def main(ctx):
     # Version shown as latest in generated documentations
     # It's fine that this is out of date in version branches, usually just needs
     # adjustment in master/deployment_branch when a new version is added to site.yml
-    latest_version = "11.7"
+    latest_version = "11.7.1"
     default_branch = "master"
 
     # Current version branch (used to determine when changes are supposed to be pushed)

--- a/site.yml
+++ b/site.yml
@@ -23,7 +23,7 @@ asciidoc:
     idprefix: ''
     idseparator: '-'
     experimental: ''
-    latest-ios-app-version: 11.7
+    latest-ios-app-version: 11.7.1
     previous-ios-app-version: 11.7
   extensions:
     - ./lib/extensions/tabs.js


### PR DESCRIPTION
According the info from @hosy, a new iOS app release will be published soon.

These are the changes in this repo needed for the upcoming 11.7.1 version of the iOS app.

Post merging we need to finalize with following tasks:
* Branch protection and renaming according the process defined
* Create a new PR in docs reflecting the version change here
