### PR TITLE
Using release notes

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -13,3 +13,4 @@
 * xref:appendices/index.adoc[Appendices]
 ** xref:appendices/mdm.adoc[Mobile Device Management (MDM)]
 ** xref:appendices/troubleshooting.adoc[Troubleshooting]
+** xref:appendices/release_notes.adoc[Release Notes]

--- a/modules/ROOT/pages/appendices/release_notes.adoc
+++ b/modules/ROOT/pages/appendices/release_notes.adoc
@@ -1,0 +1,6 @@
+= Release Notes
+:ios-changelog-url: https://github.com/owncloud/ios-app/blob/master/CHANGELOG.md
+
+== Changelog for the iOS App
+
+ownCloud provides a full changelog with a summary and details for each release of the iOS App. Click the following link to access it at {ios-changelog-url}[GitHub].


### PR DESCRIPTION
Using release notes in the same way we have them in the Android docs, see : https://github.com/owncloud/docs-client-android/pull/6 (Update release notes)

Referencing the iOS version of course 😃 

Backport to 11.7