### PR TITLE
Improve crash log description

### DIFF
--- a/modules/ROOT/pages/appendices/troubleshooting.adoc
+++ b/modules/ROOT/pages/appendices/troubleshooting.adoc
@@ -13,36 +13,40 @@
 
 == Introduction
 
-If you experience problems while using the iOS app, you can use this guide to help find the solution.
+If you experience problems while using the iOS app, you can use this guide to hopefully find a solution.
 
 == Logging
+
+=== Locating App Logs and iOS App Crash Logs
+
+There are two kinds of logs recorded in different locations:
+
+.The Log Created by the iOS App
+See xref:ios_troubleshooting.html#capturing-app-debug-logs[Capturing App Debug Logs] for how to enable app logs.
+On the same screen where you enable logging, you can access the log files. Touch menu:Share log file[] which opens a new screen with all the log files created. To export the selected logs, tap the share button on the top right-hand side of the screen.
+
+.The iOS Crash Log
+If the iOS app isn't responding or is crashing, iOS saves a crash log on the device. You can find the crash log on your device under menu:Settings[Privacy > Analytics > Analytics Data]. The log entries are sorted alphabetically with the app name, the date and a computer-readable timestamp. Tap the log of choice to open the crash log and export it with the share button on the top right-hand side of the screen.
 
 === Capturing App Debug Logs
 
 Effectively debugging software requires as much relevant information as possible. Log output can help with tracking down problems and, if you report a bug, log output can help to resolve an issue more quickly. To assist the ownCloud support personnel, please try to provide as many relevant logs as possible. You can do this by enabling and fully configuring the iOS app’s logging functionality via:
 
-* Enabling logging, _if it is not already enabled_.
-* Setting the log level to "_Debug_" or "_Info_".
-* Then, enabling:
-** Log HTTP requests and responses.
-** Standard error output.
-** Log file.
+* Enabling logging with menu:Settings[Logging > Enable Logging]
+* Setting the log level to "_Debug_" or "_Info_"
+* Enable:
+** Log HTTP requests and responses
+** Standard error output
+** Log file
 
 Once these have been enabled:
 
-* Click btn:[Reset log file].
+* Click btn:[Reset log file]
 * Perform the steps to reproduce the error
-* Go back to the Logging settings and click btn:[Share log file].
+* Go back to the Logging settings and click btn:[Share log file]
 
 .All iOS App logging settings enabled and set
 image:appendices/troubleshooting/ios-app-settings-logging.png[ios-app-settings-logging, width=35%,pdfwidth=35%]
-
-=== Locating iPhone & iPad App Crash Logs
-
-In the worst case scenario, when the app either isn't responding or is crashing, iOS saves a crash log
-on the device. You can find it under menu:Settings[Privacy > Analytics > Analytics Data].
-On iOS 12, the log entries are sorted alphabetically with the app name and date and time. 
-Tap the name to open and export with the share button on the top right-hand side.
 
 === ownCloud's Log File
 


### PR DESCRIPTION
Takeover from: https://github.com/owncloud/ios-app/pull/1016 ([Docs] Improve crash log description)

Improve the logging description
* Adding text
* Fixing capture description

Backport to 11.7