### PR TITLE
Add example specfiles to mdm

### DIFF
--- a/modules/ROOT/assets/attachments/log-passcode-specfile.xml
+++ b/modules/ROOT/assets/attachments/log-passcode-specfile.xml
@@ -1,0 +1,66 @@
+<managedAppConfiguration>
+	<version>1</version>
+	<bundleId>com.owncloud.ios-app</bundleId>
+	<dict>
+        <integer keyName="log.log-level">
+            <defaultValue>
+                <value>4</value>
+            </defaultValue>
+            <constraints  min="0" max="4" >
+            </constraints>
+        </integer>
+        <boolean keyName="log.log-privacy-mask">
+        </boolean>
+         <string keyName="log.log-format">
+            <defaultValue>
+                <value>text</value> 
+            </defaultValue>
+        </string>
+        <boolean keyName="passcode.enforced">
+        </boolean>
+	</dict>
+<presentation defaultLocale="en-US">
+    <fieldGroup>
+        <name>
+            <language value="en-US">Logging</language>
+        </name>
+        <field keyName="log.log-level" type="input">
+            <label>
+                <language value="en-US">Log Level</language>
+            </label>
+            <description>
+                <language value="en-US">0 - Debug, 1 - Info, 2 - Warning, 3 - Error, 4 - Off</language>
+            </description>
+        </field>
+        <field keyName="log.log-privacy-mask" type="checkbox">
+            <label>
+                <language value="en-US">Log Privacy Mask</language>
+            </label>
+            <description>
+                <language value="en-US">Hide private user's data</language>
+            </description>
+        </field>
+        <field keyName="log.log-format" type="input">
+            <label>
+                <language value="en-US">Log format</language>
+            </label>
+            <description>
+                <language value="en-US">Options: text, json, json-composed</language>
+            </description>
+        </field>
+    </fieldGroup>
+    <fieldGroup>
+        <name>
+            <language value="en-US">Passcode</language>
+        </name>
+        <field keyName="passcode.enforced" type="checkbox">
+            <label>
+                <language value="en-US">Enforce passcode</language>
+            </label>
+            <description>
+                <language value="en-US">User is forced to set up passcode</language>
+            </description>
+        </field>
+    </fieldGroup>
+	</presentation>
+</managedAppConfiguration>

--- a/modules/ROOT/assets/attachments/minimal-specfile.xml
+++ b/modules/ROOT/assets/attachments/minimal-specfile.xml
@@ -1,0 +1,36 @@
+<managedAppConfiguration>
+	<version>1</version>
+	<bundleId>com.owncloud.ios-app</bundleId>
+	<dict>
+		<string keyName="bookmark.default-url">
+			<defaultValue>
+				<value>ios.owncloud-demo.com</value>
+			</defaultValue>
+		</string>
+		<boolean keyName="bookmark.url-editable">
+		</boolean>
+	</dict>
+	<presentation defaultLocale="en-US">
+	<fieldGroup>
+		<name>
+			<language value="en-US">Bookmark Setttings</language>
+		</name>
+		<field keyName="bookmark.default-url" type="input">
+			<label>
+				<language value="en-US">Default Server URL</language>
+			</label>
+			<description>
+				<language value="en-US">Allows to define default server URL</language>
+			</description>
+		</field>
+		<field keyName="bookmark.url-editable" type="checkbox">
+			<label>
+				<language value="en-US">Server URL changeable</language>
+			</label>
+			<description>
+				<language value="en-US">Enables or disables changing server URL</language>
+			</description>
+		</field>
+	</fieldGroup>
+	</presentation>
+</managedAppConfiguration>

--- a/modules/ROOT/assets/attachments/specfile.xml
+++ b/modules/ROOT/assets/attachments/specfile.xml
@@ -1,0 +1,206 @@
+<managedAppConfiguration>
+	<version>1</version>
+	<bundleId>com.owncloud.ios-app</bundleId>
+	<dict>
+		<string keyName="authentication-oauth2.oa2-authorization-endpoint">
+			<defaultValue>
+				<value>index.php/apps/oauth2/authorize</value> 
+			</defaultValue>
+		</string>
+		<string keyName="authentication-oauth2.oa2-token-endpoint">
+			<defaultValue>
+				<value>index.php/apps/oauth2/api/v1/token</value> 
+			</defaultValue>
+		</string>
+		<string keyName="authentication-oauth2.oa2-redirect-uri">
+			<defaultValue>
+				<value>oc://ios.owncloud.com</value> 
+			</defaultValue>
+		</string>
+		<stringArray keyName="connection.connection-preferred-authentication-methods">
+			<defaultValue>
+				<value>com.owncloud.oauth2</value>
+				<value>com.owncloud.basicauth</value>
+			</defaultValue>
+		</stringArray>
+		<string keyName="authentication-oauth2.oa2-client-secret">
+			<defaultValue>
+				<value>KFeFWWEZO9TkisIQzR3fo7hfiMXlOpaqP8CFuTbSHzV1TUuGECglPxpiVKJfOXIx</value> 
+			</defaultValue>
+		</string>
+		<string keyName="authentication-oauth2.oa2-client-id">
+			<defaultValue>
+				<value>mxd5OQDk6es5LzOzRvidJNfXLUZS2oN3oUFeXPP8LpPrhx3UroJFduGEYIBOxkY1</value> 
+			</defaultValue>
+		</string>
+		<stringArray keyName="connection.connection-allowed-authentication-methods">
+		</stringArray>
+		<string keyName="connection.endpoint-capabilities">
+			<defaultValue>
+				<value>ocs/v1.php/cloud/capabilities</value> 
+			</defaultValue>
+		</string>
+		<string keyName="connection.endpoint-status">
+			<defaultValue>
+				<value>status.php</value> 
+			</defaultValue>
+		</string>
+		<string keyName="connection.endpoint-user">
+			<defaultValue>
+				<value>ocs/v1.php/cloud/user</value> 
+			</defaultValue>
+		</string>
+		<string keyName="connection.endpoint-webdav">
+			<defaultValue>
+				<value>remote.php/dav/files</value> 
+			</defaultValue>
+		</string>
+        <integer keyName="log.log-level">
+            <defaultValue>
+                <value>4</value>
+            </defaultValue>
+            <constraints  min="0" max="4" >
+            </constraints>
+        </integer>
+        <boolean keyName="log.log-privacy-mask">
+        </boolean>
+         <string keyName="log.log-format">
+            <defaultValue>
+                <value>text</value> 
+            </defaultValue>
+        </string>
+        <boolean keyName="passcode.enforced">
+        </boolean>
+	</dict>
+<presentation defaultLocale="en-US">
+    <fieldGroup>
+        <name>
+            <!-- Language will be the next thing the Spec Creator Tool will support. Only English supported at the moment -->
+            <language value="en-US">OAuth2 Settings</language>
+        </name>
+        <field keyName="authentication-oauth2.oa2-authorization-endpoint" type="input">
+            <label>
+                <language value="en-US">Authorization Endpoint</language>
+            </label>
+        </field>
+        <field keyName="authentication-oauth2.oa2-token-endpoint" type="input">
+            <label>
+                <language value="en-US">Token Endpoint</language>
+            </label>
+        </field>
+        <field keyName="authentication-oauth2.oa2-redirect-uri" type="input">
+            <label>
+                <language value="en-US">Redirect URI</language>
+            </label>
+        </field>
+        <field keyName="authentication-oauth2.oa2-client-secret" type="input">
+            <label>
+                <language value="en-US">Client Secret</language>
+            </label>
+        </field>
+        <field keyName="authentication-oauth2.oa2-client-id" type="input">
+            <label>
+                <language value="en-US">Client ID</language>
+            </label>
+        </field>
+    </fieldGroup>
+    <fieldGroup>
+        <name>
+            <!-- Language will be the next thing the Spec Creator Tool will support. Only English supported at the moment -->
+            <language value="en-US">Authentication Methods</language>
+        </name>
+        <field keyName="connection.connection-preferred-authentication-methods" type="list">
+            <label>
+                <language value="en-US">Preferred Authentication Method Identifiers</language>
+            </label>
+            <description>
+                <language value="en-US">Identifiers of preferred authentication methods in order of preference</language>
+            </description>
+        </field>
+        <field keyName="connection.connection-allowed-authentication-methods" type="multiselect">
+            <label>
+                <language value="en-US">Allowed Authentication Method Identifiers</language>
+            </label>
+            <description>
+                <language value="en-US">Select none to allow all methods.</language>
+            </description>
+            <options>
+                <option value="com.owncloud.oauth2">
+                    <language value="en-US">com.owncloud.oauth2</language>
+                </option>
+                <option value="com.owncloud.basicauth">
+                    <language value="en-US">com.owncloud.basicauth</language>
+                </option>
+            </options>
+        </field>
+    </fieldGroup>
+    <fieldGroup>
+        <name>
+            <!-- Language will be the next thing the Spec Creator Tool will support. Only English supported at the moment -->
+            <language value="en-US">Endpoints</language>
+        </name>
+        <field keyName="connection.endpoint-capabilities" type="input">
+            <label>
+                <language value="en-US">Capabilities Endpoint</language>
+            </label>
+        </field>
+        <field keyName="connection.endpoint-status" type="input">
+            <label>
+                <language value="en-US">Status Endpoint</language>
+            </label>
+        </field>
+        <field keyName="connection.endpoint-user" type="input">
+            <label>
+                <language value="en-US">User Endpoint</language>
+            </label>
+        </field>
+        <field keyName="connection.endpoint-webdav" type="input">
+            <label>
+                <language value="en-US">WebDAV Endpoint</language>
+            </label>
+        </field>
+    </fieldGroup>
+    <fieldGroup>
+        <name>
+            <language value="en-US">Logging</language>
+        </name>
+        <field keyName="log.log-level" type="input">
+            <label>
+                <language value="en-US">Log Level</language>
+            </label>
+            <description>
+                <language value="en-US">0 - Debug, 1 - Info, 2 - Warning, 3 - Error, 4 - Off</language>
+            </description>
+        </field>
+        <field keyName="log.log-privacy-mask" type="checkbox">
+            <label>
+                <language value="en-US">Log Privacy Mask</language>
+            </label>
+            <description>
+                <language value="en-US">Hide private user's data</language>
+            </description>
+        </field>
+        <field keyName="log.log-format" type="input">
+            <label>
+                <language value="en-US">Log format</language>
+            </label>
+            <description>
+                <language value="en-US">Options: text, json, json-composed</language>
+            </description>
+        </field>
+    </fieldGroup>
+    <fieldGroup>
+        <name>
+            <language value="en-US">Passcode</language>
+        </name>
+        <field keyName="passcode.enforced" type="checkbox">
+            <label>
+                <language value="en-US">Enforce passcode</language>
+            </label>
+            <description>
+                <language value="en-US">User is forced to set up passcode</language>
+            </description>
+        </field>
+    </fieldGroup>
+	</presentation>
+</managedAppConfiguration>

--- a/modules/ROOT/pages/appendices/mdm.adoc
+++ b/modules/ROOT/pages/appendices/mdm.adoc
@@ -111,25 +111,31 @@ include::./mdm_tables.adoc[tag=logging]
 
 AppConfig conformant spec file tailored to administrator needs and containing one or more of the above settings can be easily created using {appconfig-url}/www/appconfigspeccreator/[Config Spec Creator] tool hosted at {appconfig-url}[AppConfig website].
 
+owncloud provides three example specfiles:
+
+* link:{attachmentsdir}/specfile.xml[specfile.xml]
+* link:{attachmentsdir}/minimal-specfile.xml[minimal-specfile.xml]
+* link:{attachmentsdir}/log-passcode-specfile.xml[log-passcode-specfile.xml]
+
 == Example: Deployment With MobileIron
 
 1. Open {appconfig-jam-url}[AppConfig Generator]
-2. Upload a specfile.xml.
-3. Change the configuration options.
-4. Download the generated plist file (ManagedAppConfig).
-5. Open MobileIron Core.
+2. Upload a specfile.xml
+3. Change the configuration options
+4. Download the generated plist file (ManagedAppConfig)
+5. Open MobileIron Core
 6. Navigate to menu:Policies and Configs[Add New > Apple > iOS/tvOS > Managed App Config]
 7. Upload the generated plist and specify name, bundle ID, and description
 
 == Example: Deployment With Jamf Pro
 
 1. Open {appconfig-jam-url}[AppConfig Generator]
-2. Upload a specfile.xml.
-3. Change the configuration options.
-4. Copy Dictionary (button).
-5. Open Jamf Pro.
+2. Upload a specfile.xml
+3. Change the configuration options
+4. Copy Dictionary (button)
+5. Open Jamf Pro
 6. Navigate to menu:Devices[Mobile Device Apps > ownCloud - File Sync and Share > iOS/tvOS > App Configuration > Edit]
-7. Paste the generated Dictionary into the "Preferences" field.
+7. Paste the generated Dictionary into the "Preferences" field
 
 == References
 


### PR DESCRIPTION
Takeover from: https://github.com/owncloud/ios-app/pull/753 ([Docs] Link to specfile examples)

Adding example specfiles.
Note that the referenced PR has a broken link, therefore the files were added into the docs and provided via links.

Backport to 11.7