### PR TITLE
changes necessary for 11.8

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -6,7 +6,7 @@ def main(ctx):
     # Version shown as latest in generated documentations
     # It's fine that this is out of date in version branches, usually just needs
     # adjustment in master/deployment_branch when a new version is added to site.yml
-    latest_version = "11.7.1"
+    latest_version = "11.8"
     default_branch = "master"
 
     # Current version branch (used to determine when changes are supposed to be pushed)

--- a/site.yml
+++ b/site.yml
@@ -23,7 +23,7 @@ asciidoc:
     idprefix: ''
     idseparator: '-'
     experimental: ''
-    latest-ios-app-version: 11.7.1
+    latest-ios-app-version: 11.8
     previous-ios-app-version: 11.7
   extensions:
     - ./lib/extensions/tabs.js


### PR DESCRIPTION
These are the changes necessary to finalize the creation of the 11.8 branch.

The 11.8 branch is already pushed, prepared and is included in the branch protection rules.

Note that the 11.8 branch in this repo is already created, but the `latest` pointer on the web
will be set to it automatically when the tag in the ios-app is set. This means, that in the docs homepage,
`latest` will point to 11.7 until the tag in the ios-app repo is set accordingly.
Note, this PR must be merged *before* the 11.8 tag in the ios-app repo is set to avoid a 404 for `latest`. 

Against the explanation, discussion, ios-app release template and descripton ect, someone already set the tag to 11.8 in the the ios-app repo which currently leads to a 404 in the docs web page for the ios app 🤦‍♂️ 

Note, that this PR ist the part for this repo, but there is an additional task in the docs repo which will be linked when created.

@hosy @michaelstingl @michl19  @xoxys fyi

@EParzefall @phil-davis
post merging this, we need to backport all relevant changes to 11.8