### PR TITLE
Update the mdm table file for 11.7 only (hardcoded)

### DIFF
--- a/modules/ROOT/pages/appendices/mdm_tables.adoc
+++ b/modules/ROOT/pages/appendices/mdm_tables.adoc
@@ -1,4 +1,3 @@
-
 tag::actions[]
 [cols="1,2,3,4a,5",options=header]
 |=== 
@@ -1322,5 +1321,3 @@ Examples of expressions:
 
 |===
 end::security[]
-
-


### PR DESCRIPTION
References: https://github.com/owncloud/ios-app/pull/1094 ([docs/folder-structure] Changed Docs Structure / MDM)

This PR updates the mdm_tables for 11.7 only.
Note that the file is the 11.7 tag version.
The table is hardcoded as file an not dynamically included as it will be in master (soon).

No backport