### PR TITLE
Update the mdm table file for 11.8 only (hardcoded)

### DIFF
--- a/modules/ROOT/pages/appendices/mdm_tables.adoc
+++ b/modules/ROOT/pages/appendices/mdm_tables.adoc
@@ -1,3 +1,22 @@
+tag::account[]
+[cols="1,2,3,4a,5",options=header]
+|=== 
+|Key
+|Type
+|Default
+|Description
+|Status
+
+
+|account.auto-connect
+|bool
+|`false`
+|Skip "Account" screen / automatically open "Files" screen after login
+|supported `candidate`
+
+|===
+end::account[]
+
 
 tag::actions[]
 [cols="1,2,3,4a,5",options=header]
@@ -249,6 +268,9 @@ tag::authentication[]
 !===
 ! Value
 ! Description
+! `AWBrowser`
+! Replace `http` with `awb` and `https` with `awbs` to delegate browser sessions to the AirWatch browser.
+
 ! `CustomScheme`
 ! Replace http and https with custom schemes to delegate browser sessions to a different app.
 
@@ -317,6 +339,27 @@ tag::branding[]
 |App name to use throughout the app.
 |supported `candidate`
 
+|branding.disabled-import-methods
+|stringArray
+|
+|List of disabled import methods that can't be used.
+[cols="1,2"]
+!===
+! Value
+! Description
+! `file-provider`
+! Disallow import through the File Provider (Files.app)
+
+! `open-with`
+! Disallow import through "Open with"
+
+! `share-extension`
+! Disallow import through the Share Extension
+
+!===
+
+|supported `candidate`
+
 |branding.organization-name
 |string
 |
@@ -361,6 +404,14 @@ branding.send-feedback-address
 |Email address to send feedback to. Set to `null` to disable this feature.
 |advanced `candidate`
 
+|**Feedback URL** +
+ +
+branding.send-feedback-url
+|string
+|
+|URL to open when selecting the "Send feedback" option. Allows the use of all placeholders provided in `http.user-agent`.
+|advanced `candidate`
+
 |branding.theme-definitions
 |dictionaryArray
 |
@@ -377,7 +428,7 @@ branding.send-feedback-address
  +
 branding.url-documentation
 |urlString
-|`https://doc.owncloud.com/ios-app/`
+|`https://doc.owncloud.com/ios-app/latest/`
 |URL to documentation for the app. Opened when selecting "Documentation" in the settings.
 |advanced `candidate`
 
@@ -403,6 +454,12 @@ branding.url-terms-of-use
 |urlString
 |`https://raw.githubusercontent.com/owncloud/ios-app/master/LICENSE`
 |URL to terms of use for the app. Opened when selecting "Terms Of Use" in the settings.
+|advanced `candidate`
+
+|branding.user-defaults-default-values
+|dictionary
+|
+|Default values for user defaults. Allows overriding default settings.
 |advanced `candidate`
 
 |`Profile` +
@@ -576,6 +633,38 @@ tag::browsersession[]
 end::browsersession[]
 
 
+tag::build[]
+[cols="1,2,3,4a,5",options=header]
+|=== 
+|Key
+|Type
+|Default
+|Description
+|Status
+
+
+|build.custom-app-scheme
+|string
+|`owncloud`
+|Name of the URL scheme to use for private links. Must be provided in Branding.plist at build time. For documentation, please see doc/BUILD_CUSTOMIZATION.md.
+|supported `candidate`
+
+|build.custom-auth-scheme
+|string
+|`oc`
+|Name of the URL scheme to use for OAuth2/OIDC authentication. Must be provided in Branding.plist at build time. The authentication redirect URI parameters must also be changed accordingly in Branding.plist and on the server side. For documentation, please see doc/BUILD_CUSTOMIZATION.md.
+|supported `candidate`
+
+|build.flags
+|string
+|
+|A set of space separated flags to customize the build. Must be provided in Branding.plist at build time. For documentation, please see doc/BUILD_CUSTOMIZATION.md.
+|supported `candidate`
+
+|===
+end::build[]
+
+
 tag::connection[]
 [cols="1,2,3,4a,5",options=header]
 |=== 
@@ -652,8 +741,8 @@ The following placeholders can be used to make it dynamic:
 
 |core.scan-for-changes-interval
 |int
-|`10`
-|Minimum number of seconds until the next scan for changes, measured from the completion of the previous scan.
+|
+|Minimum number of milliseconds until the next scan for changes, measured from the completion of the previous scan. If no value is provided, uses the poll interval provided in the server's capabilities (in milliseconds) if it is greater or equal 5 seconds. Defaults to 10 seconds otherwise.
 |advanced `candidate`
 
 |connection.allow-background-url-sessions
@@ -873,6 +962,28 @@ tag::licensing[]
 
 |===
 end::licensing[]
+
+
+tag::localization[]
+[cols="1,2,3,4a,5",options=header]
+|=== 
+|Key
+|Type
+|Default
+|Description
+|Status
+
+
+|**Localization Overrides** +
+ +
+locale.overrides
+|dictionary
+|`map[]`
+|Dictionary with localization overrides where the key is the English string whose localization should be overridden, and the value is a dictionary where the keys are the language codes (f.ex. "en", "de") and the values the translations to use.
+|advanced `candidate`
+
+|===
+end::localization[]
 
 
 tag::logging[]
@@ -1131,7 +1242,13 @@ tag::passcode[]
 |passcode.enforced
 |bool
 |`false`
-|Controls wether the user MUST establish a passcode upon app installation
+|Controls wether the user MUST establish a passcode upon app installation.
+|advanced `candidate`
+
+|passcode.lockDelay
+|int
+|
+|Number of seconds before the lock snaps and the passcode is requested again.
 |advanced `candidate`
 
 |passcode.maximumPasscodeDigits
@@ -1144,6 +1261,12 @@ tag::passcode[]
 |int
 |`4`
 |Controls how many passcode digits are at least required for passcode lock.
+|advanced `candidate`
+
+|passcode.use-biometrical-unlock
+|bool
+|`false`
+|Controls wether the biometrical unlock will be enabled automatically.
 |advanced `candidate`
 
 |===
@@ -1322,5 +1445,3 @@ Examples of expressions:
 
 |===
 end::security[]
-
-


### PR DESCRIPTION
References: https://github.com/owncloud/ios-app/pull/1094 ([docs/folder-structure] Changed Docs Structure / MDM)

This PR updates the mdm_tables for 11.8 only.
Note that the file is the 11.8 tag version.
The table is hardcoded as file an not dynamically included as it will be in master (soon).

No backport