### PR TITLE
Changes Necessary For 11.11

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -6,7 +6,7 @@ def main(ctx):
     # Version shown as latest in generated documentations
     # It's fine that this is out of date in version branches, usually just needs
     # adjustment in master/deployment_branch when a new version is added to site.yml
-    latest_version = "11.10"
+    latest_version = "11.11"
     default_branch = "master"
 
     # Current version branch (used to determine when changes are supposed to be pushed)

--- a/site.yml
+++ b/site.yml
@@ -28,8 +28,8 @@ asciidoc:
     idseparator: '-'
     experimental: ''
 #   ios-app
-    latest-ios-app-version: '11.10'
-    previous-ios-app-version: '11.9'
+    latest-ios-app-version: '11.11'
+    previous-ios-app-version: '11.10'
   extensions:
     - ./lib/extensions/tabs.js
     - ./lib/extensions/remote-include-processor.js


### PR DESCRIPTION
Referencing: #114 (Release 11.11.0)

**IMPORTANT**: when 11.11 has been tagged, we need to fix the version attribute for mdm in antora.yml in the 11.11 branch. 

These are the changes necessary to finalize the creation of the 11.11 branch.

The 11.11 branch is already pushed and prepared and is included in the branch protection rules.

When 11.11 (iOS-App) is finally out, the 11.9 branch can be archived,
see step 4 in https://github.com/owncloud/docs-client-ios-app/blob/master/docs/new-version-branch.md

Note, that the 11.11 branch in this repo is already created, but the `latest` pointer on the web
will be set to it automatically when the tag in iOS-App repo is set. This means, that in the docs homepage,
`latest` will point to 11.10 until the tag in iOS-App repo is set accordingly. When merging this PR,
11.9 will be dropped from the web but is available via pdf as usual.

Note, this PR must be merged before the 11.11 tag in the iOS-App repo is set to avoid a 404 for `latest`.

Note that a PR in docs must be made to announce the 11.11 branch. The docs PR must be merged AFTER this PR is merged to avoid a CI error in docs.

Before merging this PR, we should take care that 11.9 has all changes necessary merged as post
merging the 11.9 pdf is fixed.

@michaelstingl @hosy fyi

@mmattel @EParzefall @phil-davis
post merging this, we need to backport all relevant changes to 11.11