### PR TITLE
Move and update the description attribute to the correct place

### DIFF
--- a/modules/ROOT/pages/accounts.adoc
+++ b/modules/ROOT/pages/accounts.adoc
@@ -1,9 +1,9 @@
 = Managing User Accounts
 :page-aliases: ios_accounts.adoc
 :toc: right
+:description: This guide steps you through how to manage user accounts in ownCloud’s iOS app. It includes the authentication types, and how to add, update, remove, and delete user accounts.
 
 :keywords: user accounts, OAuth2 authentication, basic authentication, ownCloud iOS App
-:description: This guide steps you through how to manage user accounts in ownCloud’s iOS app; including the authentication types, and how to add, update, remove, and delete user accounts.
 :sfauthenticationsession-url: https://developer.apple.com/documentation/safariservices/sfauthenticationsession
 :aswebauthenticationsession-url: https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession
 :oauth2-app-url: https://marketplace.owncloud.com/apps/oauth2
@@ -11,7 +11,7 @@
 
 == Introduction
 
-With the iOS app, users can access their data from several ownCloud instances. They can use one or more accounts for the same server, or accounts for other ownCloud servers they have access to.
+{description} With the iOS app, users can access their data from several ownCloud instances. They can use one or more accounts for the same server, or accounts for other ownCloud servers they have access to.
 
 == Authentication Methods
 
@@ -27,7 +27,7 @@ The iOS app supports two ways of authentication options for user accounts. These
 * Login Credentials are stored on the device (secured in the iOS system keychain).
 * Password manager support.
 
-image:accounts/02_basic_auth.png[basic authentication, width=35%,pdfwidth=35%]
+image::accounts/02_basic_auth.png[basic authentication, width=250]
 
 === OAuth 2.0
 
@@ -43,17 +43,17 @@ Additionally, OAuth2 is the industry standard authorisation method, and the user
 
 === Add an Account
 
-image:accounts/04_Account_1x.png[Add a user account in the ownCloud iOS App., width=40%,pdfwidth=40%]
+image::accounts/04_Account_1x.png[Add a user account in the ownCloud iOS App., width=250]
 
 To add one or more user accounts to the iOS app, when in the "*Accounts*" view, click the plus (+) icon in the top right-hand corner. This opens the "*Add Account*" dialog, where you can enter the URL of the ownCloud server. After you enter it and click "Continue", the iOS app checks the authentication method and the validity of the SSL/TLS certificate (_if the server URL uses the HTTPS protocol_).
 
 If the certificate is deemed to be valid, you will see a green "*Passed*" symbol near the bottom of the page, next to "*Certificate Details*", and the text "*No issues found. Certificate passed validation.*"
 
-image:accounts/add-account-certificate-passed-validation.png[Authenticate a user account using OAuth2 in the ownCloud iOS App., width=35%,pdfwidth=35%]
+image::accounts/add-account-certificate-passed-validation.png[Authenticate a user account using OAuth2 in the ownCloud iOS App., width=250]
 
 Click btn:[Continue] and the app will prompt you if you want to use the supplied server URL to sign in to the app. You will then be redirected to the ownCloud server, where you can supply your username and password. After doing so, and submitting the form, you will then be asked if you want to give permission for the app to access your account. 
 
-image:accounts/14_OAuth_Web_view_authorize.png[Authorize a user account against an ownCloud server with the ownCloud iOS App., width=35%,pdfwidth=35%]
+image::accounts/14_OAuth_Web_view_authorize.png[Authorize a user account against an ownCloud server with the ownCloud iOS App., width=250]
 
 * If so, click btn:[Authorize]. 
 * If not, click btn:[Cancel].
@@ -68,11 +68,11 @@ ownCloud server must have {oauth2-app-url}[the OAuth2 app] installed, configured
 
 If you want to delete an account, when viewing the Accounts list, swipe left on the account that you want to delete and click btn:[Delete].
 
-image:accounts/edit-or-delete-account.png[How to edit and delete an account in the ownCloud iOS app Accounts list, width=35%,pdfwidth=35%]
+image::accounts/edit-or-delete-account.png[How to edit and delete an account in the ownCloud iOS app Accounts list, width=250]
 
 You will then be asked if you really want to delete that account. 
 
-image:accounts/confirm-account-deletion.png[Confirm account deletion in the ownCloud iOS app, width=35%,pdfwidth=35%]
+image::accounts/confirm-account-deletion.png[Confirm account deletion in the ownCloud iOS app, width=350]
 
 If you do, click btn:[Delete]. Doing so deletes the account from the device, as well as all locally stored file copies. If you don’t want to delete the account, click btn:[Cancel].
 
@@ -80,7 +80,7 @@ If you do, click btn:[Delete]. Doing so deletes the account from the device, as 
 
 If you want to edit an account, when viewing the Accounts list, swipe left on the account that you want to edit and click btn:[Edit].
 
-image:accounts/edit-or-delete-account.png[How to edit and delete an account in the ownCloud iOS app Accounts list, width=35%,pdfwidth=35%]
+image::accounts/edit-or-delete-account.png[How to edit and delete an account in the ownCloud iOS app Accounts list, width=250]
 
 You will then be able to change the ownCloud server URL, and manage the authentication credentials. How the authentication credentials can be managed depends on the authentication type.
 
@@ -94,6 +94,6 @@ a different password, as well as delete their authentication data.
 | The user is authenticated using OAuth2 authentication. In this setup, they will only be able
 to delete their OAuth2 authentication.
 
-a| image::accounts/07_Account_edit.png[ownCloud iOS App - Authenticating users using Basic Authentication, width=60%,pdfwidth=60%]
-a| image::accounts/edit-oauth2-authenticated-account.png[ownCloud iOS App - Authenticating users using OAuth2 Authentication, width=60%,pdfwidth=60S%]
+a| image::accounts/07_Account_edit.png[ownCloud iOS App - Authenticating users using Basic Authentication, width=250]
+a| image::accounts/edit-oauth2-authenticated-account.png[ownCloud iOS App - Authenticating users using OAuth2 Authentication, width=250]
 |===

--- a/modules/ROOT/pages/appendices/mdm.adoc
+++ b/modules/ROOT/pages/appendices/mdm.adoc
@@ -1,9 +1,9 @@
 = Mobile Device Management (MDM)
-:page-aliases: ios_mdm.adoc
 :toc: right
+:description: With the introduction of MDM (Mobile Device Management) by Apple for its devices, a MDM server can securely push a configuration to the iOS device, respectively recieve feedback from the device. ownCloud supports MDM for it's iOS-App.
+:page-aliases: ios_mdm.adoc
 
 :keywords: ownCloud, MDM, Mobile Device Management, iOS, iPhone, iPad
-:description: This guide steps you through how to manage the application configuration of ownCloud’s Mobile App for iOS using Mobile Device Management (MDM).
 :appconfig-xml-format-url: https://www.appconfig.org/ios/
 :mdm-protocol-ref-url: https://developer.apple.com/business/documentation/MDM-Protocol-Reference.pdf
 :appconfig-url: https://www.appconfig.org
@@ -11,12 +11,12 @@
 :mdm-protocol-refernce-url: https://developer.apple.com/business/documentation/MDM-Protocol-Reference.pdf
 
 // note that the attribute definition for linking the correct mdm file from the ios-repo (configuration.adoc) is maintained in antora.yml as this is branch specific and must be maintained per branch - in particular the mdm-tag-name attribute.
-
-:description: With the introduction of MDM (Mobile Device Management) by Apple for its devices, a MDM server can securely push a configuration to the iOS device, respectively recieve feedback from the device. ownCloud supports MDM for it's iOS-App.
  
 == Introduction
 
-{description} The configuration is basically a key-value dictionary provided as a `.plist` file. The app can access this configuration from the server in read-only mode using the `NSUserDefaults` class by reading a configuration dictionary under the key `_com.apple.configuration.managed_`. The app can also observe a system notification via class `NSUserDefaultsDidChangeNotification` to get notified about configuration changes. For feedback, the app writes a dictionary with feedback information into user defaults under the `_com.apple.feedback.managed_` key.
+{description}
+
+The configuration is basically a key-value dictionary provided as a `.plist` file. The app can access this configuration from the server in read-only mode using the `NSUserDefaults` class by reading a configuration dictionary under the key `_com.apple.configuration.managed_`. The app can also observe a system notification via class `NSUserDefaultsDidChangeNotification` to get notified about configuration changes. For feedback, the app writes a dictionary with feedback information into user defaults under the `_com.apple.feedback.managed_` key.
 
 == Configurable Settings
 

--- a/modules/ROOT/pages/appendices/troubleshooting.adoc
+++ b/modules/ROOT/pages/appendices/troubleshooting.adoc
@@ -1,6 +1,7 @@
 = Troubleshooting
-:page-aliases: ios_troubleshooting.adoc, troubleshooting.adoc
 :toc: right
+:description: If you experience problems while using the iOS app, you can use this guide to hopefully find a solution.
+:page-aliases: ios_troubleshooting.adoc, troubleshooting.adoc
 
 :keywords: troubleshooting, logging, debugging, mitmproxy, charles for iOS, ownCloud, iOS, iPhone, iPad
 :description: This guide steps you through how to troubleshoot issues with ownCloud's iOS App for iPhone and iPad. Specifically, it shows how to configure logging, and troubleshoot using mitmproxy and Charles for iOS.
@@ -13,7 +14,7 @@
 
 == Introduction
 
-If you experience problems while using the iOS app, you can use this guide to hopefully find a solution.
+{description}
 
 == Logging
 
@@ -49,13 +50,17 @@ Once these have been enabled:
 .All iOS App logging settings enabled and set
 [width=80%,cols="^.^35%,^.^5%,^.^35%",frame=none,grid=none]
 |===
-a| image::appendices/troubleshooting/ios-app-settings-logging.png[ios-app-settings-logging]
+a| image::appendices/troubleshooting/ios-app-settings-logging.png[ios-app-settings-logging, width=250]
 a| *->*
-a| image::appendices/troubleshooting/ios-app-settings-logging1.png[ios-app-settings-logging]
+a| image::appendices/troubleshooting/ios-app-settings-logging1.png[ios-app-settings-logging, width=250]
 |===
 
+[caption=]
 .Button to clear the logs
-image:appendices/troubleshooting/ios-app-settings-logging2.png[ios-app-settings-logging, width=35%,pdfwidth=35%]
+[width=37%,cols="^.^35%",frame=none,grid=none]
+|===
+a| image:appendices/troubleshooting/ios-app-settings-logging2.png[ios-app-settings-logging, width=250]
+|===
 
 === ownCloud's Log File
 
@@ -66,7 +71,7 @@ menu:Settings[General (Admin)]. On that page, you can adjust the log level.
 We recommend that you set it to a verbose level such as either `debug` or `info`.
 
 .Configuring logging in ownCloud server.
-image:appendices/troubleshooting/owncloud-log-configuration.png[Configuring logging in ownCloud server. ,width=40%,pdfwidth=40%]
+image::appendices/troubleshooting/owncloud-log-configuration.png[Configuring logging in ownCloud server., width=350]
 
 === Web Server Log Files
 
@@ -122,7 +127,7 @@ If you need to check the traffic between ownCloud and the iOS App, we recommend 
 {mitmproxy-url}[mitmproxy] is an interactive man-in-the-middle proxy for HTTP and HTTPS with a console interface.
 At ownCloud, we use it a lot to investigate every detail of HTTP requests and responses.
 
-image:appendices/troubleshooting/mitmproxy_screenshot.png[mitmproxy sample output, width=100%,pdfwidth=100%]
+image::appendices/troubleshooting/mitmproxy_screenshot.png[mitmproxy sample output, width=500]
 
 === Charles for iOS
 

--- a/modules/ROOT/pages/available_offline.adoc
+++ b/modules/ROOT/pages/available_offline.adoc
@@ -1,10 +1,11 @@
 = Offline Files and Folders
-:page-aliases: ios_available_offline.adoc
 :toc: right
+:description: The ownCloud iOS app supports offline storage of files and folders, allowing them to be accessed even when an internet connection is temporarily unavailable.
+:page-aliases: ios_available_offline.adoc
 
 == Introduction
 
-From version 1.1.0, the ownCloud iOS app supports offline storage of files and folders, allowing them to be accessed even when an internet connection is temporarily unavailable.
+{description}
 
 == Making a File or Folder Available Offline
 
@@ -15,12 +16,12 @@ To make a file or folder available offline, click on the _More_ icon and press "
 ^| Make file available offline
 ^| Make folder available offline
 
-a| image::available-offline/make-available-offline.png[Make files and folders available offline in the ownCloud iOS app, width=60%,pdfwidth=60%]
-a| image::available-offline/folder-action.png[Make files and folders available offline in the ownCloud iOS app, width=60%,pdfwidth=60%]
+a| image::available-offline/make-available-offline.png[Make files and folders available offline in the ownCloud iOS app, width=250]
+a| image::available-offline/folder-action.png[Make files and folders available offline in the ownCloud iOS app, width=250]
 |===
 
 Files that have been made available offline are identifiable by the available offline icon. You can see an example of the icon image below. +
-image:available-offline/available-offline-logo.png[,width=6%,pdfwidth=6%].
+image::available-offline/available-offline-logo.png[,width=350].
 
 == Removing a File or Folder from Offline Storage
 
@@ -28,10 +29,10 @@ Any file or folder that has been made available offline can also be removed from
 
 * By pressing the _More_ icon next to a file or folder and pressing "_Available offline_" from the list of available actions.
 +
-image:available-offline/file-available-offline.png[Make an item unavailable offline in the ownCloud iOS app, width=35%,pdfwidth=35%]
+image::available-offline/file-available-offline.png[Make an item unavailable offline in the ownCloud iOS app, width=250]
 * By swiping left on an item in the Available Offline Locations list and pressing "_Make unavailable offline_".
 +
-image:available-offline/make-unavailable-offline.png[Make an item unavailable offline by swiping left from the Available Offline Locations list in the ownCloud iOS app, width=40%,pdfwidth=40%]
+image::available-offline/make-unavailable-offline.png[Make an item unavailable offline by swiping left from the Available Offline Locations list in the ownCloud iOS app, width=250]
 
 == Viewing Offline Files
 
@@ -47,14 +48,14 @@ If one or more files have been marked as available offline, then you have two wa
 In the screenshot below, you can see that there are one or more files in the _Photos_ directory that have been marked as available offline. If you tap one of the available directories, you will then see all files in that directory that are available offline, similar to how you would view files normally. 
 
 .View offline files by location
-image:available-offline/one-folder-available-offline.png[, width=35%,pdfwidth=35%]
+image::available-offline/one-folder-available-offline.png[, width=250]
 
 === View a List of All Offline Files
 
 In the screenshot below, you can see all the items that have been marked as available offline.
 
 .View all offline files
-image:available-offline/all-available-offline-items.png[, width=35%,pdfwidth=35%]
+image::available-offline/all-available-offline-items.png[, width=250]
 
 == Storage
 
@@ -62,4 +63,4 @@ Locally available file copies can be set to be automatically deleted after a spe
 
 NOTE: This setting applies to all local files, not just available offline files.
 
-image:available-offline/offline-storage-settings.png[Offline Storage options in the ownCloud iOS app, width=35%,pdfwidth=35%]
+image::available-offline/offline-storage-settings.png[Offline Storage options in the ownCloud iOS app, width=250]

--- a/modules/ROOT/pages/collaboration.adoc
+++ b/modules/ROOT/pages/collaboration.adoc
@@ -1,14 +1,15 @@
 = Collaboration and Links
-:page-aliases: ios_collaboration.adoc
 :toc: right
+:description: This section shows how to collaborate with other users and how to work with links.
+:page-aliases: ios_collaboration.adoc
 
 == Introduction
 
-This section shows how to collaborate with other users and how to work with links.
+{description}
 
 == Collaborate With Other Users on Files and Folders
 
-image:collaboration/31_Collab.png[Collaborate With Other Users on Folders and Files, width=35%,pdfwidth=35%]
+image::collaboration/31_Collab.png[Collaborate With Other Users on Folders and Files, width=250]
 
 The Mobile App for iOS supports the following collaboration functionality:
 
@@ -44,17 +45,17 @@ As with the web interface, you can set:
 * Link permissions
 * xref:set-passwords-and-expiration-dates[A link password and expiration date]
 
-image:collaboration/manage-public-link-settings.png[Manage public links in ownCloud's Mobile App for iOS, width=35%,pdfwidth=35%]
+image::collaboration/manage-public-link-settings.png[Manage public links in ownCloud's Mobile App for iOS, width=250]
 
 TIP: To see more details about each option, click the info icon in the bottom right-hand corner.
 
 ==== Set Passwords and Expiration Dates
 
-image:collaboration/public-link-set-password.png[Set a password for a public link in ownCloud's Mobile App for iOS, width=35%,pdfwidth=35%]
+image::collaboration/public-link-set-password.png[Set a password for a public link in ownCloud's Mobile App for iOS, width=250]
 
 To set a password on a public link, under "_Options_", enable btn:[Password]. Then, type a password in the field that appears below the Password option.
 
-image:collaboration/public-link-set-expiration-date.png[Set an expiration date for a public link in ownCloud's MobileApp for iOS, width=35%,pdfwidth=35%]
+image::collaboration/public-link-set-expiration-date.png[Set an expiration date for a public link in ownCloud's MobileApp for iOS, width=250]
 
 To set an expiration date on a public link, under "_Options_", enable btn:[Expiration date]. Then, pick the date that the link should expire with the date picker that appears below the Expiration date option.
 
@@ -72,9 +73,9 @@ There are two ways to delete a public link.
 
 . When viewing the list of links for a file or folder, swipe left on the link that you want to delete,
   and click btn:[Delete]. +
-  image:collaboration/swipe-and-delete-public-link.png[, width=35%,pdfwidth=35%]
+  image::collaboration/swipe-and-delete-public-link.png[, width=250]
 . When viewing the Public Link, click btn:[Delete] at the bottom of the page, under btn:[Copy Public Link]. +
-  image:collaboration/delete-public-link.png[Delete a Public Link in ownCloud’s iOS app, by clicking Delete at the bottom of the Public Link details page, width=35%,pdfwidth=35%]
+  image::collaboration/delete-public-link.png[Delete a Public Link in ownCloud’s iOS app, by clicking Delete at the bottom of the Public Link details page, width=250]
 
 === View Public Links
 

--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -1,7 +1,8 @@
 = iOS Frequently Asked Questions (FAQ)
-:page-aliases: ios_faq.adoc
 :toc: right
-:hardbreaks:
+:description: Here you can find some of the most frequently asked questions about the ownCloud iOS app.
+:page-aliases: ios_faq.adoc
+
 :oauth2-app-url: https://marketplace.owncloud.com/apps/oauth2
 :ios-legacy-appstore-url: https://apps.apple.com/app/id543672169
 :ios-app-tx-url: https://www.transifex.com/owncloud-org/owncloud/mobile-ios-app/
@@ -10,7 +11,7 @@
 
 == Introduction
 
-Here you can find some of the most frequently asked questions about the ownCloud iOS app.
+{description}
 
 == Usage
 

--- a/modules/ROOT/pages/files.adoc
+++ b/modules/ROOT/pages/files.adoc
@@ -1,16 +1,16 @@
 = Managing Files
 :page-aliases: ios_files.adoc
 :toc: right
-
-:keywords: PDF, Drag & Drop, Photo Library, iPhone, iPad, ownCloud iOS App
 :description: This guide steps you through how to manage files and directories in ownCloud's iOS app; You will learn all about uploading, moving, dragging and dropping, and viewing files, file and folder actions, and navigating folders.
+:keywords: PDF, Drag & Drop, Photo Library, iPhone, iPad, ownCloud iOS App
+
 :ios-safari-supported-filetypes-url: https://stackoverflow.com/a/46334049
 :icons: font
 :multitasking-on-ipad-url: https://support.apple.com/en-us/HT207582
 
 == Introduction
 
-The IOS app provides a number of features designed to make managing files as simple as possible.
+{description}
 
 == Features
 
@@ -22,7 +22,7 @@ The IOS app provides a number of features designed to make managing files as sim
 * Folder actions
 * Select all/none
 
-image:files/21_File_list_annotated.png[Overview of the ownCloud iOS App's files view., width=60%,pdfwidth=60%]
+image::files/21_File_list_annotated.png[Overview of the ownCloud iOS App's files view., width=350]
 
 Click on a file to view it and click on a folder to view its contents. To view further actions available for a file or folder, click the _More_ icon on the far right-hand side.
 
@@ -48,8 +48,8 @@ However, file actions are handled slightly differently, depending on whether one
 | File popup for actions for _individual_ files
 | Move icon row for _multiple-selected_ files
 
-a| image::files/file-actions.jpg[File actions dialog for individual files in ownCloud's iOS App., width=60%,pdfwidth=60%]
-a| image::files/file-actions-multiple-files-selected.png[File actions dialog for multiple-selected files in ownCloud's iOS App., width=100%,pdfwidth=100%]
+a| image::files/file-actions.jpg[File actions dialog for individual files in ownCloud's iOS App., width=300]
+a| image::files/file-actions-multiple-files-selected.png[File actions dialog for multiple-selected files in ownCloud's iOS App., width=300]
 |===
 
 NOTE: The file size values differ depending on the client you are using. Some operating systems like iOS and macOS use the decimal system (power of 10) where 1kB or one kilobyte consists of 1000 bytes, while Linux, Android and Windows use the binary system (power of 2) where 1KB consists of 1024 bytes and is called a kibibyte. So no reason to worry if you see different file sizes in the desktop client and on your mobile device.
@@ -59,7 +59,7 @@ NOTE: The file size values differ depending on the client you are using. Some op
 
 There are two ways to navigate folders (outside of the root folder). To go back to the parent folder, tap btn:[Back] in the top left-hand corner. To navigate directly to *any* parent folder, tap on the current folder's name. When you do, you will see the names of all the parent folders, right up to the root folder, as in the image below.
 
-image:files/21_File_list_parent.png[Navigating folders in ownCloud's iOS app, width=35%,pdfwidth=35%]
+image::files/21_File_list_parent.png[Navigating folders in ownCloud's iOS app, width=200]
 
 == Navigate Files
 
@@ -67,7 +67,7 @@ When navigating files, as you would expect, you can scroll up and down the files
 
 NOTE: The index bar is only visible, if the sort order is `Name`.
 
-image:files/index-bar-with-callout.png[Navigating files in ownCloud's iOS app, width=40%,pdfwidth=40%]
+image::files/index-bar-with-callout.png[Navigating files in ownCloud's iOS app, width=350]
 
 == Sort Files and Folders
 
@@ -78,8 +78,8 @@ By default, files and folders are sorted by name in ascending order, with folder
 | *Sorting files and folders in portrait mode*
 | *Sorting files and folders in landscape mode*
 
-a| image:files/sort-files-portrait-mode.png[Sorting files and folders in portrait mode, width=80%,pdfwidth=80%]
-a| image:files/sort-files-landscape-mode.png[Sorting files and folders in landscape mode, width=80%,pdfwidth=80%]
+a| image::files/sort-files-portrait-mode.png[Sorting files and folders in portrait mode, width=250]
+a| image::files/sort-files-landscape-mode.png[Sorting files and folders in landscape mode, width=250]
 |===
 
 == View Files
@@ -90,11 +90,11 @@ To view a file, tap on its name in the file list. Any file type
 [NOTE]
 ====
 If the file is not available locally on the device, you will see
-image:files/icon-not-available-locally.png[alt=A file is not downloaded locally on the ownCloud iOS app, width=4%,pdfwidth=4%]
+image:files/icon-not-available-locally.png[alt=A file is not downloaded locally on the ownCloud iOS app, width=25]
 next to the file.
 
 When you click on it, you will see
-image:files/icon-download.png[alt=A file is downloading on the ownCloud iOS app, width=4%,pdfwidth=4%]
+image:files/icon-download.png[alt=A file is downloading on the ownCloud iOS app, width=22]
 next to it while it downloads.
 ====
 
@@ -104,16 +104,16 @@ next to it while it downloads.
 | An image file
 | A video file
 | A PDF file
-a| image::files/view-file-image.png[Viewing an image file in the ownCloud iOS App, width=60%,pdfwidth=60%]
-a| image::files/view-file-video.png[Viewing a video file in the ownCloud iOS App, width=60%,pdfwidth=60%]
-a| image::files/view-file-pdf.png[Viewing a PDF file in the ownCloud iOS App, width=60%,pdfwidth=60%]
+a| image::files/view-file-image.png[Viewing an image file in the ownCloud iOS App, width=250]
+a| image::files/view-file-video.png[Viewing a video file in the ownCloud iOS App, width=250]
+a| image::files/view-file-pdf.png[Viewing a PDF file in the ownCloud iOS App, width=250]
 
 | A text file
 | An ODT file.
 |
 
-a| image::files/view-file-text-file.png[Viewing a text file in the ownCloud iOS App, width=60%,pdfwidth=60%]
-a| image::files/view-file-odt.png[Viewing an ODT file in the ownCloud iOS App, width=60%,pdfwidth=60%]
+a| image::files/view-file-text-file.png[Viewing a text file in the ownCloud iOS App, width=250]
+a| image::files/view-file-odt.png[Viewing an ODT file in the ownCloud iOS App, width=250]
 |
 |===
 
@@ -136,10 +136,10 @@ You can see an example of each in the images below.
 | Page thumbnails
 | File search
 
-a| image::files/41_PDF.png[Page selector in PDF files in the ownCloud iOS App, width=60%,pdfwidth=60%]
-a| image::files/42_PDF_toc.png[Table of contents in PDF files in the ownCloud iOS App, width=60%,pdfwidth=60%]
-a| image::files/43_PDF_thumbs.png[Page thumbnails in PDF files in the ownCloud iOS App, width=60%,pdfwidth=60%]
-a| image::files/44_PDF_search.png[File search in PDF files in the ownCloud iOS App, width=60%,pdfwidth=60%]
+a| image::files/41_PDF.png[Page selector in PDF files in the ownCloud iOS App, width=250]
+a| image::files/42_PDF_toc.png[Table of contents in PDF files in the ownCloud iOS App, width=250]
+a| image::files/43_PDF_thumbs.png[Page thumbnails in PDF files in the ownCloud iOS App, width=250]
+a| image::files/44_PDF_search.png[File search in PDF files in the ownCloud iOS App, width=250]
 |===
 
 === Video Files
@@ -155,13 +155,13 @@ When working with folders, click the plus icon near the top right-hand corner, a
 * xref:upload-file-from-your-photo-library[Upload file from your photo library]
 * xref:make-available-offline[Make available offline]
 
-image:files/directory-actions.png[Folder actions in ownCloud's iOS App., width=35%,pdfwidth=35%]
+image::files/directory-actions.png[Folder actions in ownCloud's iOS App., width=250]
 
 === Create Folder
 
 To create a new folder, click btn:[Create folder], enter the name of the new folder, as in the image below, and click btn:[return].
 
-image:files/create-new-folder.png[How to create a new folder in ownCloud's iOS App., width=35%,pdfwidth=35%]
+image::files/create-new-folder.png[How to create a new folder in ownCloud's iOS App., width=250]
 
 === Upload Files
 
@@ -175,7 +175,7 @@ Please see the xref:available_offline.adoc[Offline Storage section].
 
 To upload photos from your photo library, you first need to allow the iOS app access to your photos. After that, you can browse through your photos, as you normally would. You can then select one or more photos by pressing them, or click btn:[Select All] in the bottom left-hand corner to select all photos in the current folder. When you're happy with your photo selection, click btn:[Upload] and the photo(s) will be uploaded.
 
-image:files/24_Upload_Photo_multi.png[Upload one or more photos from your Photo Library with the ownCloud iOS App., width=35%,pdfwidth=35%]
+image::files/24_Upload_Photo_multi.png[Upload one or more photos from your Photo Library with the ownCloud iOS App., width=250]
 
 === Move Files and Folders
 
@@ -184,13 +184,13 @@ Whether you are using the iPhone or iPad version of the ownCloud app, you can se
 * Drag and drop them over a folder in the current directory
 * Drag and drop them over the "*Move to*" icon (or tap the icon), near the bottom left-hand side of the screen. You then navigate to the folder that you want to move them to and click btn:[Move here] at the bottom of the screen.
 
-image:files/26_Files_multidragdrop.png[Move multiple files (and folders) to another location in the ownCloud iOS App., width=35%,pdfwidth=35%]
+image::files/26_Files_multidragdrop.png[Move multiple files (and folders) to another location in the ownCloud iOS App., width=250]
 
 [NOTE] 
 ====
 If a file or folder with the same name as one or more of those being moved, already exists in the destination directory, you will see a warning that the file or folder could not be moved.
 
-image:files/file-with-same-name-already-exists.png[ownCloud iOS App, file or folder with the same name already exists in the destination directory., width=40%,pdfwidth=40%]
+image::files/file-with-same-name-already-exists.png[ownCloud iOS App, file or folder with the same name already exists in the destination directory., width=250]
 ====
 
 == Drag & Drop Files Between Apps (iPad-only)
@@ -199,4 +199,4 @@ The iOS app supports the multitasking features on iPad. If you open it as a seco
 {multitasking-on-ipad-url}[Multitasking On Your iPad guide] for more information.
 
 .Drag and drop multiple files from ownCloud iOS App to macOS Notes
-image:files/26_Files_multidragdrop_iPad.png[Drag and Drop Files Between Apps (iPad-only) in ownCloud's iOS App., width=70%,pdfwidth=70%]
+image::files/26_Files_multidragdrop_iPad.png[Drag and Drop Files Between Apps (iPad-only) in ownCloud's iOS App., width=350]

--- a/modules/ROOT/pages/files_integration.adoc
+++ b/modules/ROOT/pages/files_integration.adoc
@@ -1,13 +1,12 @@
 = iOS App and iOS Files App Integration and 3rd Party Apps
-:page-aliases: ios_files_integration.adoc
 :toc: right
-
+:description: This guide steps you through ownCloud's Mobile App for iOS’s integration with the iOS Files App. When enabled, you can open, edit, save, and delete files and folders.
 :keywords: Files App, iOS, iPhone, iPad, ownCloud
-:description: This guide steps you through ownCloud's Mobile App for iOS’s integration with the iOS Files App.
+:page-aliases: ios_files_integration.adoc
 
 == Introduction
 
-The Mobile App for iOS integrates with the iOS Files App. When enabled, you can open, edit, save, and delete files and folders. However, the functionality needs to first be enabled.
+{description} However, the functionality needs to first be enabled.
 
 == Work With Your ownCloud Data in iOS Files App
 
@@ -33,7 +32,7 @@ When the iOS app is installed and at least one account is properly configured, f
 | Pick a file to "Save to Files"
 | Pick the location to save the file and click "Add"
 
-a| image::files_integration/enable-location.png[Enable the ownCloud app as an iOS Files app location, width=60%,pdfwidth=60%]
-a| image::files_integration/share-files-from-other-apps-step-1.png[Pick a file to Save to Files, width=60%,pdfwidth=60%]
-a| image::files_integration/share-files-from-other-apps-step-2.png[Pick the location to save the file and click Add, width=60%,pdfwidth=60%]
+a| image::files_integration/enable-location.png[Enable the ownCloud app as an iOS Files app location, width=250]
+a| image::files_integration/share-files-from-other-apps-step-1.png[Pick a file to Save to Files, width=250]
+a| image::files_integration/share-files-from-other-apps-step-2.png[Pick the location to save the file and click Add, width=250]
 |===

--- a/modules/ROOT/pages/installation.adoc
+++ b/modules/ROOT/pages/installation.adoc
@@ -7,6 +7,6 @@
 To get the ownCloud iOS App, point Safari, or your favorite web browser, to your ownCloud server. Next, log in and navigate to menu:Settings[General (Personal)]. At the bottom of that page, you will see a link to the ownCloud app on iTunes.
 
 .Links to ownCloud's mobile apps.
-image:installation/owncloud-server-mobile-apps.png[Links to ownCloud's mobile apps for Desktop and the Google Play and iOS App Stores., width=40%,pdfwidth=40%]
+image::installation/owncloud-server-mobile-apps.png[Links to ownCloud's mobile apps for Desktop and the Google Play and iOS App Stores., width=400]
 
 TIP: You'll also find links and information on the ownCloud installation page.

--- a/modules/ROOT/pages/quick_access.adoc
+++ b/modules/ROOT/pages/quick_access.adoc
@@ -1,15 +1,15 @@
 = Quick Access
 :page-aliases: ios_quick_access.adoc
 :toc: right
+:description: This guide steps you through how to use the Quick Access functionality of ownCloud's Mobile App for iOS.
 
 :keywords: shares, collection, recently access files, quick access, ownCloud, iOS, iPhone, iPad
-:description: This guide steps you through how to use the Quick Access functionality of ownCloud's Mobile App for iOS.
 
 == Introduction
 
-The app allows you to quickly access the key aspects of the application, by clicking btn:[Quick Access], located in the footer of the application.
+{description} To do so, click btn:[Quick Access], located in the footer of the application.
 
-image:quick-access/quick-access-view.png[Get quick access to the most important parts of ownCloud's iOS App for iPhone and iPad., width=35%,pdfwidth=35%]
+image::quick-access/quick-access-view.png[Get quick access to the most important parts of ownCloud's iOS App for iPhone and iPad., width=250]
 
 Quick access is broken down into two sections: _Shares_ and _Collection_.
 

--- a/modules/ROOT/pages/security.adoc
+++ b/modules/ROOT/pages/security.adoc
@@ -1,7 +1,7 @@
 = Security
 :page-aliases: ios_security.adoc
 :toc: right
-// :toclevels: 1
+:description: This document provides an overview of the security considerations and features
 
 :keywords: ownCloud, security, encryption, mdm, ssl, tls, oauth2, authentication, ios, iphone, ipad
 :description: This guide steps you through the security features of of ownCloud's Mobile App for iOS.
@@ -27,7 +27,7 @@
 
 == Introduction
 
-This document provides an overview of the security considerations and features in the new {owncloud-ios-sdk}[ownCloud iOS SDK] and new {owncloud-ios-app}[ownCloud iOS App].
+{description} in the new {owncloud-ios-sdk}[ownCloud iOS SDK] and new {owncloud-ios-app}[ownCloud iOS App].
 
 == Authentication
 
@@ -89,7 +89,7 @@ If a SSL/TLS certificate fails trust evaluation (e.g., because it's self-signed 
 * Trust the certificate, despite the warnings, by clicking btn:[Approve].
 * Reject the certificate, by clicking btn:[Cancel].
 
-image:security/04_cert_error.png[Review SSL/TLS certificates in the ownCloud iOS app., width=35%,pdfwidth=35%]
+image::security/04_cert_error.png[Review SSL/TLS certificates in the ownCloud iOS app., width=250]
 
 In the case of redirects across several HTTPS servers, users are given the opportunity to review the certificates of all servers involved in addition to the redirects.
 

--- a/modules/ROOT/pages/settings.adoc
+++ b/modules/ROOT/pages/settings.adoc
@@ -1,20 +1,20 @@
 = Configure Settings
 :page-aliases: ios_settings.adoc
 :toc: right
-
-:keywords: settings, passcode lock, biometric lock, theme, logging, ownCloud, iOS, iPhone, iPad
 :description: This guide steps you through how to configure ownCloud's iOS App for iPhone and iPad. It covers security, theme, logging, and media upload settings.
+:keywords: settings, passcode lock, biometric lock, theme, logging, ownCloud, iOS, iPhone, iPad
+
 :heic-image-url: https://en.wikipedia.org/wiki/High_Efficiency_Image_File_Format
 
 == Introduction
 
-This document describes which settings are available and how to set them
+{description}
 
 == Settings Screen
 
 To manage the settings in ownCloud's iOS App for iPhone and iPad, click btn:[Settings] in the bottom right-hand corner of the Accounts List view.
 
-image:settings/user-accounts-list-annotated-with-callout.png[Accessing settings in ownCloud's iOS App for iPhone and iPad., width=35%,pdfwidth=35%]
+image::settings/user-accounts-list-annotated-with-callout.png[Accessing settings in ownCloud's iOS App for iPhone and iPad., width=300]
 
 == Security
 
@@ -23,19 +23,19 @@ image:settings/user-accounts-list-annotated-with-callout.png[Accessing settings 
 To protect access to the iOS app with a Passcode, enable btn:[Passcode Lock] in the Setting’s Security section. You will then be prompted to enter, and repeat, a 4-digit Passcode.
 If a Passcode was set, the file provider extension in Files.app or in other third party apps will be locked too. The file provider presents a UI to unlock the Passcode.
 
-image:settings/security-passcode-enabled.png[Enable a Passcode lock in ownCloud's iOS App for iPhone and iPad., width=35%,pdfwidth=35%]
+image::settings/security-passcode-enabled.png[Enable a Passcode lock in ownCloud's iOS App for iPhone and iPad., width=300]
 
 === Lock Delay
 
 When a Passcode is enabled, the app will be locked every time you change to another application. However, under menu:Settings[Security > Lock application], you can choose to only lock the application after 1, 5, or 30 minutes, instead of "_immediately_", which is the default.
 
-image:settings/lock-application-duration.png[Set the application lock duration in ownCloud's iOS App for iPhone and iPad., width=35%,pdfwidth=35%]
+image::settings/lock-application-duration.png[Set the application lock duration in ownCloud's iOS App for iPhone and iPad., width=300]
 
 === Biometrical Lock
 
 After a Passcode has been created, a Biometrical Lock, or Touch ID, can also be used to gain access to the app. To enable it enable btn:[Touch ID] in the Setting's _Security_ section, and then enter your 4-digit Passcode. The next time you need to authorise access to the app, you will be able to enter either your Passcode, or use your stored biometrical data.
 
-image:settings/authorise-access-with-passcode-or-biometric-data.png[Authorise access with passcode or biometric data in ownCloud's iOS App for iPhone and iPad., width=35%,pdfwidth=35%]
+image::settings/authorise-access-with-passcode-or-biometric-data.png[Authorise access with passcode or biometric data in ownCloud's iOS App for iPhone and iPad., width=300]
 
 === Trusted Certificates
 
@@ -50,7 +50,7 @@ To view previously approved certificates, swipe left on any of the accounts in t
 
 ==== Revoke Previously Approved Certificates
 
-image:settings/83_Settings_certs.png[83_Settings_certs.png, width=35%,pdfwidth=35%]
+image::settings/83_Settings_certs.png[83_Settings_certs.png, width=300]
 
 To revoke one or more previously approved certificates, first navigate to
 menu:Settings[Certificates] (for any one of your registered accounts). Then, in the "_User-Approved Certificates_" section, swipe left on the certificate(s) that you wish to revoke and press btn:[Revoke approval].
@@ -65,7 +65,7 @@ The iOS app comes with three themes:
 
 To change the theme, navigate to menu:Settings[Theme], and pick the one that you want. 
 
-image:settings/84_Settings_themes.png[84_Settings_themes.png, width=35%,pdfwidth=35%]
+image::settings/84_Settings_themes.png[84_Settings_themes.png, width=350]
 
 .The three themes in ownCloud's iOS App for iPhone and iPad.
 [cols="^33%,^33%,^33%",options="header"]
@@ -74,9 +74,9 @@ image:settings/84_Settings_themes.png[84_Settings_themes.png, width=35%,pdfwidth
 | Dark theme
 | Light theme
 
-a| image::settings/themes/classic.png[ownCloud iOS App - Classic theme]
-a| image::settings/themes/dark.png[ownCloud iOS App - Dark theme]
-a| image::settings/themes/light.png[ownCloud iOS App - Light theme]
+a| image::settings/themes/classic.png[ownCloud iOS App - Classic theme, width=250]
+a| image::settings/themes/dark.png[ownCloud iOS App - Dark theme, width=250]
+a| image::settings/themes/light.png[ownCloud iOS App - Light theme, width=250]
 |===
 
 === System Appearance (up from iOS 13)
@@ -92,7 +92,7 @@ xref:troubleshooting.adoc#capturing-app-debug-logs[logging section of the Troubl
 
 When image and video files are uploaded, they can be converted to the industry-standard JPEG and MP4 respectively. This is not done by default. 
 
-image:settings/media-upload.png[The media upload (conversion) settings in ownCloud's iOS App for iPhone and iPad., width=40%,pdfwidth=40%]
+image::settings/media-upload.png[The media upload (conversion) settings in ownCloud's iOS App for iPhone and iPad., width=300]
 
 === Image
 

--- a/modules/ROOT/pages/task_scheduling.adoc
+++ b/modules/ROOT/pages/task_scheduling.adoc
@@ -1,10 +1,11 @@
 = Task Scheduling
-:page-aliases: ios_task_scheduling.adoc
 :toc: right
+:description: Background tasks are scheduled based on the app's current context, and that context is based on a combination of factors.
+:page-aliases: ios_task_scheduling.adoc
 
 == Introduction
 
-Background tasks are scheduled based on the app's current context, and that context is based on a combination of factors. These factors include:
+{description} These factors include:
 
 * Is the app backgrounded or in the foreground?
 * Is WiFi available?


### PR DESCRIPTION
**This is no content change !**

When using the attribute `:description:` which creates a meta tag in htm for search engines when rendered, you need to use two rules:

* It must be under the section header, not in aprticular order, but without a blank line above
* You must not use any links or attributes like `xref:{url}[text]` - will not get resolved and taken as it is

Found by chance. This PR corrects this for the docs-client-android repo.

This will now make search engines print predefined text more likely than before when returning search results.

Additionally fixed image positions and size.

Backport to 11.11