### PR TITLE
[12.0] Remove iOS version in antora.yml

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,5 +1,5 @@
 name: ios-app
-title: Mobile App for iOS (iOS 11+)
+title: Mobile App for iOS
 version: '12.0'
 start_page: ROOT:index.adoc
 nav:


### PR DESCRIPTION
References: #146 

We no longer have to differentiate between legacy iOS app and new iOs app.
