### PR TITLE
Remove release notes

### DIFF
--- a/modules/ROOT/pages/appendices/release_notes.adoc
+++ b/modules/ROOT/pages/appendices/release_notes.adoc
@@ -1,6 +1,0 @@
-= Release Notes
-:ios-changelog-url: https://github.com/owncloud/ios-app/blob/master/CHANGELOG.md
-
-== Changelog for the iOS App
-
-ownCloud provides a full changelog with a summary and details for each release of the iOS App. Click the following link to access it at {ios-changelog-url}[GitHub].

--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -13,4 +13,3 @@
 * xref:appendices/index.adoc[Appendices]
 ** xref:appendices/mdm.adoc[Mobile Device Management (MDM)]
 ** xref:appendices/troubleshooting.adoc[Troubleshooting]
-** xref:appendices/release_notes.adoc[Release Notes]


### PR DESCRIPTION
References: https://github.com/owncloud/docs-main/pull/29 (Adding iOS and Android release notes)

Backport to 12.1 and 12.0

