### PR TITLE
Changes necessary for iOS 12.2

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -6,7 +6,7 @@ def main(ctx):
     # Version shown as latest in generated documentations
     # It's fine that this is out of date in version branches, usually just needs
     # adjustment in master/deployment_branch when a new version is added to site.yml
-    latest_version = "12.1"
+    latest_version = "12.2"
     default_branch = "master"
 
     # Current version branch (used to determine when changes are supposed to be pushed)


### PR DESCRIPTION
These are the changes necessary to finalize the creation of the 12.2 branch.

* The 12.2 branch is already pushed and prepared and is included in the branch protection rules.

* When 12.2 is finally out, the 12.0 branch can be archived, see step 3 in [Create a New Version Branch](https://github.com/owncloud/docs-client-ios-app/blob/master/docs/new-version-branch.md)

* Note, that the 12.2 branch in this repo is already created, but the `latest` pointer on the web will be set to it automatically when the tag in iOS is set. This means, that in the docs homepage, `latest` will point to 12.1 until the tag in iOS is set accordingly. When merging this PR, 12.0 will be dropped from the web.

* Note that this PR must be merged **before** the 12.2 tag in iOS is set to avoid a 404 for `latest`.

* Note before merging this PR, we should take care that 12.0 has all necessary changes merged.

@TheOneRing @hosy fyi

@mmattel @phil-davis
Post merging this, we need to backport all relevant changes to 12.2