### PR TITLE
Fix command typo in generate-index.js

### DIFF
--- a/ext-antora/generate-index.js
+++ b/ext-antora/generate-index.js
@@ -155,7 +155,7 @@ function indexDelete(client) {
         resolve(resp)
       })
       .catch((err) => {
-        console.warning(err)
+        console.warn(err)
         resolve(true)
       })
   })


### PR DESCRIPTION
`console.warning(err)` --> `console.warn(err)` :man_facepalming:

Backport to 12.2