### PR TITLE
Changes necessary for the 12.4 branch

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -6,7 +6,7 @@ def main(ctx):
     # Version shown as latest in generated documentations
     # It's fine that this is out of date in version branches, usually just needs
     # adjustment in master/deployment_branch when a new version is added to site.yml
-    latest_version = "12.3"
+    latest_version = "12.4"
     default_branch = "master"
 
     # Current version branch (used to determine when changes are supposed to be pushed)


### PR DESCRIPTION
This are the changes necessary to for the 12.4 branch. Note that it currently does not contain any content changes.

The next step is to do a small PR in the docs branch to enable the 12.4 branch for building docs.