### PR TITLE
Changes necessary for 12.5

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -6,7 +6,7 @@ def main(ctx):
     # Version shown as latest in generated documentations
     # It's fine that this is out of date in version branches, usually just needs
     # adjustment in master/deployment_branch when a new version is added to site.yml
-    latest_version = "12.4"
+    latest_version = "12.5"
     default_branch = "master"
 
     # Current version branch (used to determine when changes are supposed to be pushed)

--- a/docs/new-version-branch.md
+++ b/docs/new-version-branch.md
@@ -91,7 +91,7 @@ Currently on draft to avoid accidentally merging before x.y is finally out.
 Only merge close before the product tag gets released.
 
 When this PR is merged, the dropped branch can be archived.
-For more details see the `Create a New Version Branch` section in the README.md of the respective docs-xxx repo repo.
+For more details see the `Create a New Version Branch` section in the README.md of the respective docs-xxx repo.
 
 The `latest` pointer on the web will be set automatically when the tag in the product repo is set.
 


### PR DESCRIPTION
These are the changes necessary to finalize the creation of the 12.5 branch.

* The 12.5 branch is already pushed, prepared and is included in the branch protection rules.

* Note that this PR can be merged at any time but:
  * must be merged **before** applying content changes and
  * **before** merging the docs PR to include this version.

* Post merging this, we need to backport all relevant changes created in master to 12.5

@mmattel @phil-davis