### PR TITLE
ci: trigger owncloud/docs rebuild on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,12 @@ jobs:
 
       - name: Build documentation
         run: npm run antora
+
+  trigger-docs-build:
+    name: Trigger docs build
+    needs: docs-build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    uses: owncloud/reusable-workflows/.github/workflows/trigger-docs-build.yml@main
+    secrets:
+      DOCS_TRIGGER_APP_ID: ${{ secrets.DOCS_TRIGGER_APP_ID }}
+      DOCS_TRIGGER_APP_PRIVATE_KEY: ${{ secrets.DOCS_TRIGGER_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

- Adds a `trigger-docs-build` job that fires after a successful push to any tracked branch
- Uses a GitHub App token (scoped to `owncloud/docs` only) to call `workflow_dispatch` on `owncloud/docs` — no PAT required
- Job only runs on `push` events, skipping PRs to avoid noise

## Prerequisite

Before merging, the following org secrets must exist:
- `DOCS_TRIGGER_APP_ID`
- `DOCS_TRIGGER_APP_PRIVATE_KEY`

The GitHub App requires **Actions: Read & write** permission, installed on `owncloud/docs` only.

## Related

- Reusable workflow lives in [owncloud/reusable-workflows](https://github.com/owncloud/reusable-workflows) (`trigger-docs-build.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)