### PR TITLE
docs: normalize legacy server product name to "ownCloud Classic" (12.6)

### DIFF
--- a/modules/ROOT/pages/faq.adoc
+++ b/modules/ROOT/pages/faq.adoc
@@ -15,9 +15,9 @@
 
 == Usage
 
-=== Compatibility With ownCloud Server Older Than Version 10.0
+=== Compatibility With ownCloud Classic Older Than Version 10.0
 
-Previous ownCloud iOS app with support for ownCloud Server < 10.0 is still available in {ios-legacy-appstore-url}[App Store].
+Previous ownCloud iOS app with support for ownCloud Classic < 10.0 is still available in {ios-legacy-appstore-url}[App Store].
 
 === Compatibility With iOS Versions Older Than iOS 12.0
 


### PR DESCRIPTION
## What

Normalizes the legacy ownCloud server product to its canonical name **ownCloud Classic** across all user-facing documentation in this repo. Version (10/11) is retained only as trailing information where relevant (e.g. "ownCloud Classic 10").

Normalized: `ownCloud Server`, `owncloud Server`, `ownCloud Classic Server`, and bare `ownCloud 10/11`.

## Why

Part of owncloud/docs#5111 — a coordinated, docs-only rebranding so the legacy product is consistently named **ownCloud Classic** across the `owncloud` / `owncloud-docker` orgs. Reference implementation: owncloud/docs-main#187.

## Out of scope (intentionally untouched)

- `xref:`/`include::` targets, module slugs (`classic_ui`, `oc10-app`), URLs, attribute names (e.g. `oc10-api-url`), image paths, anchors
- The new product names: **ownCloud Infinite Scale** / **oCIS**

## Verification

- All target variants normalized; only prose / headings / link display text changed.
- Every `xref`/`include`/URL **target** byte-for-byte identical before/after.
- `oCIS` / `Infinite Scale` occurrence count unchanged.
- No internal xref depends on any heading whose auto-generated anchor changes.

## Reviewer checklist

- [ ] No xref targets / module slugs / URLs altered
- [ ] oCIS / Infinite Scale untouched
- [ ] Version shown only as additional info ("ownCloud Classic 10")

🤖 Generated with [Claude Code](https://claude.com/claude-code)
